### PR TITLE
Travis authentication

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,5 +17,6 @@ Imports:
     yaml,
     openssl,
     git2r,
+    memoise,
     devtools
 RoxygenNote: 5.0.1

--- a/R/github.R
+++ b/R/github.R
@@ -72,6 +72,7 @@ extract_repo <- function(path) {
 }
 
 auth_github <- function() {
+  message("Authenticating with GitHub")
   scopes <- c("repo", "read:org", "user:email", "write:repo_hook")
   app <- httr::oauth_app("github",
                          key = "4bca480fa14e7fb785a1",

--- a/R/github.R
+++ b/R/github.R
@@ -71,11 +71,17 @@ extract_repo <- function(path) {
   sub("^https://github.com/", "", path)
 }
 
-auth_github <- function(cache = getOption("httr_oauth_cache")) {
+auth_github_ <- function(cache = NULL) {
   message("Authenticating with GitHub")
+  if (is.null(cache)) {
+    cache <- getOption("httr_oauth_cache")
+  }
+
   scopes <- c("repo", "read:org", "user:email", "write:repo_hook")
   app <- httr::oauth_app("github",
                          key = "4bca480fa14e7fb785a1",
                          secret = "70bb4da7bab3be6828808dd6ba37d19370b042d5")
   httr::oauth2.0_token(httr::oauth_endpoints("github"), app, scope = scopes, cache = cache)
 }
+
+auth_github <- memoise::memoise(auth_github_)

--- a/R/github.R
+++ b/R/github.R
@@ -71,11 +71,11 @@ extract_repo <- function(path) {
   sub("^https://github.com/", "", path)
 }
 
-auth_github <- function() {
+auth_github <- function(cache = getOption("httr_oauth_cache")) {
   message("Authenticating with GitHub")
   scopes <- c("repo", "read:org", "user:email", "write:repo_hook")
   app <- httr::oauth_app("github",
                          key = "4bca480fa14e7fb785a1",
                          secret = "70bb4da7bab3be6828808dd6ba37d19370b042d5")
-  httr::oauth2.0_token(httr::oauth_endpoints("github"), app, scope = scopes)
+  httr::oauth2.0_token(httr::oauth_endpoints("github"), app, scope = scopes, cache = cache)
 }

--- a/R/travis.R
+++ b/R/travis.R
@@ -44,8 +44,11 @@ travis_token <- function(refresh = FALSE) {
   token$credentials
 }
 
-auth_travis <- function(gtoken = auth_github(cache = FALSE)) {
+auth_travis_ <- function(gtoken = NULL) {
   message("Authenticating with Travis")
+  if (is.null(gtoken)) {
+    gtoken <- auth_github_(cache = FALSE)
+  }
   auth_travis_data <- list(
     "github_token" = gtoken$credentials$access_token
   )
@@ -58,6 +61,8 @@ auth_travis <- function(gtoken = auth_github(cache = FALSE)) {
   httr::stop_for_status(auth_travis, "authenticate with travis")
   httr::content(auth_travis)$access_token
 }
+
+auth_travis <- memoise::memoise(auth_travis_)
 
 #' @export
 travis_accounts <- function() {

--- a/R/travis.R
+++ b/R/travis.R
@@ -35,7 +35,7 @@ TravisToken <- R6::R6Class("TravisToken", inherit = httr::Token, list(
 #' @export
 #' @rdname travis
 travis_token <- function(refresh = FALSE) {
-  gtoken <- travis:::auth_github()
+  gtoken <- travis:::auth_github_(cache = FALSE)
   app <- httr::oauth_app("travis", key = "",
                          secret = gtoken$credentials$access_token)
   endpoint <- httr::oauth_endpoint(NULL, NULL, travis('/auth/github'))
@@ -44,7 +44,7 @@ travis_token <- function(refresh = FALSE) {
   token$credentials
 }
 
-auth_travis <- function(gtoken = auth_github()) {
+auth_travis <- function(gtoken = auth_github(cache = FALSE)) {
   message("Authenticating with Travis")
   auth_travis_data <- list(
     "github_token" = gtoken$credentials$access_token

--- a/R/travis.R
+++ b/R/travis.R
@@ -45,6 +45,7 @@ travis_token <- function(refresh = FALSE) {
 }
 
 auth_travis <- function(gtoken = auth_github()) {
+  message("Authenticating with Travis")
   auth_travis_data <- list(
     "github_token" = gtoken$credentials$access_token
   )

--- a/R/travis.R
+++ b/R/travis.R
@@ -34,14 +34,8 @@ TravisToken <- R6::R6Class("TravisToken", inherit = httr::Token, list(
 #' Authenticate with Travis using your Github account. Returns an access token.
 #' @export
 #' @rdname travis
-travis_token <- function(refresh = FALSE) {
-  gtoken <- travis:::auth_github_(cache = FALSE)
-  app <- httr::oauth_app("travis", key = "",
-                         secret = gtoken$credentials$access_token)
-  endpoint <- httr::oauth_endpoint(NULL, NULL, travis('/auth/github'))
-  token <- TravisToken$new(app, endpoint)
-  if (refresh) token$refresh()
-  token$credentials
+travis_token <- function() {
+  auth_travis()
 }
 
 auth_travis_ <- function(gtoken = NULL) {

--- a/man/travis.Rd
+++ b/man/travis.Rd
@@ -6,7 +6,7 @@
 \alias{travis_token}
 \title{Authenticate with Travis}
 \usage{
-travis_token(refresh = FALSE)
+travis_token()
 
 travis_set_var(repo_id, name, value, public = FALSE)
 


### PR DESCRIPTION
Travis seems to require a new, unused GitHub token for each authentication. This PR uses memoise to reduce the actual number of auth requests in an R session, independently of httr caching.

Fixes #35.

Fixes #29.
