### PR TITLE
fix regexp to only remove trailing ".git"

### DIFF
--- a/R/remote.R
+++ b/R/remote.R
@@ -24,6 +24,6 @@ extract_repo <- function(url) {
   if (!all(grepl("^https://github.com", url))) {
     stopc("Unrecognized repo format: ", url)
   }
-  url <- sub("\\.git", "", url)
+  url <- sub("\\.git$", "", url)
   sub("^https://github.com/", "", url)
 }


### PR DESCRIPTION
currently, if the repo contains ".git" in the name (e.g. 'user/user.github.io') it gets removed leading to invalid repo URL.