### PR TITLE
More accurate checking of permissions before creating deploy key

### DIFF
--- a/R/github-key.R
+++ b/R/github-key.R
@@ -26,20 +26,18 @@ github_add_key <- function(pubkey, title = "travis+tic",
   if (!inherits(pubkey, "pubkey"))
     stopc("`pubkey` must be an RSA/EC public key")
 
-  if (info$owner$type == "User") {
-    if (is.null(gh_token)) {
+  if (is.null(gh_token)) {
+    if (info$owner$type == "User") {
       gh_token <- auth_github("public_repo")
-    }
-  } else {
-    if (is.null(gh_token)) {
+    } else {
       gh_token <- auth_github("public_repo", "write:org")
     }
-
-    check_write_org(info$owner$login, gh_token)
   }
 
-  key_data <- create_key_data(pubkey, title)
   repo <- github_repo(info = info)
+  check_admin_repo(repo, gh_token)
+
+  key_data <- create_key_data(pubkey, title)
 
   # remove existing key
   remove_key_if_exists(key_data, repo, gh_token, quiet)

--- a/R/github-org.R
+++ b/R/github-org.R
@@ -24,7 +24,7 @@ get_role_in_repo <- function(repo, gh_token) {
 }
 
 check_admin_repo <- function(repo, gh_token) {
-  role_in_repo <- get_role_in_repo(org, gh_token)
+  role_in_repo <- get_role_in_repo(repo, gh_token)
   if (role_in_repo != "admin") {
     stopc("Must have role admin to add deploy key to repo ", repo, ", not ", role_in_repo)
   }

--- a/R/github-org.R
+++ b/R/github-org.R
@@ -1,3 +1,35 @@
+github_user <- function(gh_token) {
+  req <- GITHUB_GET(paste0("/user"), token = gh_token)
+
+  httr::stop_for_status(
+    req,
+    "get information on authenticated user"
+  )
+
+  httr::content(req)
+}
+
+get_role_in_repo <- function(repo, gh_token) {
+  user <- github_user(gh_token)$login
+
+  req <- GITHUB_GET(paste0("/repos/", repo, "/collaborators/", user, "/permission"), token = gh_token)
+
+  httr::stop_for_status(
+    req,
+    paste0("get collaborator information on repo ", repo, " for user ", user)
+  )
+
+  response <- httr::content(req)
+  response$permission
+}
+
+check_admin_repo <- function(repo, gh_token) {
+  role_in_repo <- get_role_in_repo(org, gh_token)
+  if (role_in_repo != "admin") {
+    stopc("Must have role admin to add deploy key to repo ", repo, ", not ", role_in_repo)
+  }
+}
+
 get_role_in_org <- function(org, gh_token) {
   req <- GITHUB_GET(paste0("/user/memberships/orgs/", org), token = gh_token)
   if (httr::status_code(req) %in% 403) {

--- a/R/github-org.R
+++ b/R/github-org.R
@@ -1,4 +1,4 @@
-check_write_org <- function(org, gh_token) {
+get_role_in_org <- function(org, gh_token) {
   req <- GITHUB_GET(paste0("/user/memberships/orgs/", org), token = gh_token)
   if (httr::status_code(req) %in% 403) {
     org_perm_url <- paste0(
@@ -22,6 +22,11 @@ check_write_org <- function(org, gh_token) {
   membership <- httr::content(req)
   role_in_org <- membership$role
 
+  role_in_org
+}
+
+check_write_org <- function(org, gh_token) {
+  role_in_org <- get_role_in_org(org, gh_token)
   if (role_in_org != "admin") {
     stopc("Must have role admin to edit organization ", org, ", not ", role_in_org)
   }


### PR DESCRIPTION
Now uses the "collaborators" API to check if a user can add a deploy key. (Checking isn't strictly necessary, but gives a slightly better error message.)

Closes #95.