### PR TITLE
use cli for messages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ BugReports: https://github.com/ropenscilabs/travis/issues
 Depends:
     R (>= 3.1.0)
 Imports:
+    cli,
     clipr,
     git2r,
     glue (>= 1.2.0),

--- a/R/github-auth.R
+++ b/R/github-auth.R
@@ -1,5 +1,7 @@
 auth_github_ <- function(...) {
-  message("Authenticating with GitHub")
+
+  cli::cat_bullet(bullet = "pointer", bullet_col = "yellow",
+    " Authenticating to GitHub.")
   cache <- FALSE
 
   scopes <- c(...)
@@ -10,6 +12,8 @@ auth_github_ <- function(...) {
     httr::oauth_endpoints("github"), app,
     scope = scopes, cache = cache
   )
+  cli::cat_bullet(bullet = "tick", bullet_col = "green",
+    "Authentication successful.")
 }
 
 #' Authenticate with GitHub

--- a/R/github-create-repo.R
+++ b/R/github-create-repo.R
@@ -85,20 +85,24 @@ use_github <- function(path = ".", push = NA,
 
   remote_url <- ask_remote_url(new_info$ssh_url, new_info$clone_url)
 
-  if (!quiet) message("Setting origin remote to ", remote_url)
+  if (!quiet) cli::cat_bullet(bullet = "pointer", bullet_col = "yellow",
+    sprintf(" Setting origin remote to ", remote_url))
   git2r::remote_add(r, "origin", remote_url)
 
   if ("master" %in% names(git2r::branches(r, "local"))) {
     if (is.na(push)) push <- ask_push()
 
     if (push) {
-      if (!quiet) message("Pushing master to origin")
+      if (!quiet) cli::cat_bullet(bullet = "pointer", bullet_col = "yellow",
+        " Pushing master to origin.")
       git2r::push(r, "origin", "refs/heads/master")
     } else {
-      if (!quiet) message("Not pushed to GitHub yet")
+      if (!quiet) cli::cat_bullet(bullet = "pointer", bullet_col = "yellow",
+        " Not pushed to GitHub yet.")
     }
   } else {
-    if (!quiet) message("master branch not found, cannot push to GitHub")
+    if (!quiet) cli::cat_bullet(bullet_col = "red", bullet = "cross",
+      " master branch not found, cannot push to GitHub.")
   }
 
   invisible(new_info)

--- a/R/github-key.R
+++ b/R/github-key.R
@@ -44,11 +44,12 @@ github_add_key <- function(pubkey, title = "travis+tic",
   # add public key to repo deploy keys on GitHub
   ret <- add_key(key_data, repo, gh_token, quiet)
 
-  message(
-    "Successfully added public deploy key '", title, "' to GitHub for ", repo, ". ",
-    "You should receive a confirmation e-mail from GitHub. ",
-    "Delete the key in the repository's settings to revoke access for that key or when you no longer need it."
-  )
+  cli::cat_bullet(bullet = "tick", bullet_col = "green",
+    sprintf("Successfully added added public deploy key ", title, "' to GitHub for ", repo, ". "))
+  cli::cat_bullet(bullet = "pointer", bullet_col = "yellow",
+    " You should receive a confirmation e-mail from GitHub.")
+  cli::cat_bullet(bullet = "pointer", bullet_col = "yellow",
+    " Delete the key in the repository's settings to revoke access for that key or when you no longer need it.")
 
   invisible(ret)
 }

--- a/R/github-key.R
+++ b/R/github-key.R
@@ -45,7 +45,7 @@ github_add_key <- function(pubkey, title = "travis+tic",
   ret <- add_key(key_data, repo, gh_token, quiet)
 
   cli::cat_bullet(bullet = "tick", bullet_col = "green",
-    sprintf("Successfully added added public deploy key ", title, "' to GitHub for ", repo, ". "))
+    sprintf("Successfully added public deploy key ", title, "' to GitHub for ", repo, ". "))
   cli::cat_bullet(bullet = "pointer", bullet_col = "yellow",
     " You should receive a confirmation e-mail from GitHub.")
   cli::cat_bullet(bullet = "pointer", bullet_col = "yellow",

--- a/R/github-pat.R
+++ b/R/github-pat.R
@@ -24,25 +24,34 @@ github_create_pat <- function(path = ".", repo = github_repo(path)) {
 
   desc <- paste0("travis+tic for ", repo)
   clipr::write_clip(desc)
-  url_message(
-    "Create a personal access token, make sure that you are signed in as the correct user. ",
-    "The suggested description '", desc, "' has been copied to the clipboard. ",
-    "If you use this token only to avoid GitHub's rate limit, you can leave all scopes unchecked. ",
-    "Then, copy the new token to the clipboard, it will be detected and applied automatically",
-    url = "https://github.com/settings/tokens/new"
-  )
 
+  cli::cat_bullet(bullet = "pointer", bullet_col = "yellow",
+    " Creating a personal access token (PAT).")
+  cli::cat_bullet(bullet = "pointer", bullet_col = "yellow",
+    sprintf(" The suggested description '%s' has been copied to the clipboard.", desc))
+  cli::cat_bullet(bullet = "info", bullet_col = "yellow",
+    " If you use this token only to avoid GitHub's rate limit, you can leave all scopes unchecked.",)
+  cli::cat_bullet(bullet = "info", bullet_col = "yellow",
+    " Then, copy the new token to the clipboard, it will be detected and applied automatically.")
+
+  open_browser_window("https://github.com/settings/tokens/new")
   wait_for_clipboard_pat()
 }
 
 wait_for_clipboard_pat <- function() {
-  message("Waiting for PAT to appear on the clipboard.")
+
+  cli::cat_bullet(bullet = "info", bullet_col = "yellow",
+    " If you use this token only to avoid GitHub's rate limit, you can leave all scopes unchecked.")
+
+  cli::cat_bullet(bullet = "info", bullet_col = "yellow",
+    " Waiting for PAT to appear on the clipboard.")
   repeat {
     pat <- clipr::read_clip()
     if (is_pat(pat)) break
     Sys.sleep(0.1)
   }
-  message("Detected PAT, clearing clipboard.")
+  cli::cat_bullet(bullet = "pointer", bullet_col = "yellow",
+    " Detected PAT, clearing clipboard.")
   tryCatch(
     clipr::write_clip(""),
     error = function(e) {

--- a/R/github-pat.R
+++ b/R/github-pat.R
@@ -30,7 +30,7 @@ github_create_pat <- function(path = ".", repo = github_repo(path)) {
   cli::cat_bullet(bullet = "pointer", bullet_col = "yellow",
     sprintf(" The suggested description '%s' has been copied to the clipboard.", desc))
   cli::cat_bullet(bullet = "info", bullet_col = "yellow",
-    " If you use this token only to avoid GitHub's rate limit, you can leave all scopes unchecked.",)
+    " If you use this token only to avoid GitHub's rate limit, you can leave all scopes unchecked.")
   cli::cat_bullet(bullet = "info", bullet_col = "yellow",
     " Then, copy the new token to the clipboard, it will be detected and applied automatically.")
 

--- a/R/setup.R
+++ b/R/setup.R
@@ -33,8 +33,9 @@ use_travis_deploy <- function(path = ".", info = github_info(path),
 
   travis_set_var("id_rsa", private_key, public = FALSE, repo = travis_repo)
 
-  message("Successfully added private deploy key to ", travis_repo,
-          " as secure environment variable id_rsa to Travis CI.")
+  cli::cat_bullet(bullet = "tick", bullet_col = "green",
+    sprintf("Successfully added private deploy key to ",
+    travis_repo, " as secure environment variable id_rsa to Travis CI."))
 
 }
 

--- a/R/travis-auth.R
+++ b/R/travis-auth.R
@@ -1,5 +1,6 @@
 auth_travis_ <- function(gh_token = NULL) {
-  message("Authenticating with Travis")
+  cli::cat_bullet(bullet = "pointer", bullet_col = "yellow",
+    " Authenticating to GitHub.")
   if (is.null(gh_token)) {
     # Do not allow caching this token, it needs to be fresh
     gh_token <- auth_github_(


### PR DESCRIPTION
Most chatty messages have been replaced by `cli` functions.

I could not test all options of every step in the wizard because I faced #102. 

Would be great if you could test it on your side with a fake repo again. 

After approval, I'll edit the README. 

~~(This PR includes a styling of the pkg using `styler::style_pkg()`.)~~

This cluttered the diff too much.