### PR TITLE
Return informative error message if API key is invalid

### DIFF
--- a/R/travis.R
+++ b/R/travis.R
@@ -62,6 +62,11 @@ travis <- function(verb = "GET",
     query = query, encode = encode, ua, accept_json()
   )
 
+  # check for invalid token
+  if (http_type(resp) == "text/html" && status_code(resp) == 403) {
+    stopc("Possibly invalid API key detected. Please double-check and retry.")
+  }
+
   # for travis_delete_var()
   if (http_type(resp) == "application/octet-stream") {
     return(resp)

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -42,10 +42,10 @@ withr::with_dir(
       Sys.setenv("R_TRAVIS_COM" = "invalid")
 
       expect_error(travis_get_builds(repo = repo, endpoint = ".org"),
-        regexp = "Possibly invalid API key detected. Please double-check and retry." # nocov
+        regexp = "Possibly invalid API key detected. Please double-check and retry." # nolint
       )
       expect_error(travis_get_builds(repo = repo, endpoint = ".com"),
-        regexp = "Possibly invalid API key detected. Please double-check and retry." # nocov
+        regexp = "Possibly invalid API key detected. Please double-check and retry." # nolint
       )
 
       # restore

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -27,3 +27,30 @@ withr::with_dir(
     })
   }
 )
+
+withr::with_dir(
+  "travis-testthat",
+  {
+    test_that("Catch invalid API keys", {
+
+      # backup
+      api_key_org <- travis_check_api_key(".org")
+      api_key_com <- travis_check_api_key(".com")
+
+      # invalidate
+      Sys.setenv("R_TRAVIS_ORG" = "invalid")
+      Sys.setenv("R_TRAVIS_COM" = "invalid")
+
+      expect_error(travis_get_builds(repo = repo, endpoint = ".org"),
+        regexp = "Possibly invalid API key detected. Please double-check and retry." # nocov
+      )
+      expect_error(travis_get_builds(repo = repo, endpoint = ".com"),
+        regexp = "Possibly invalid API key detected. Please double-check and retry." # nocov
+      )
+
+      # restore
+      Sys.setenv("R_TRAVIS_ORG" = api_key_org)
+      Sys.setenv("R_TRAVIS_COM" = api_key_com)
+    })
+  }
+)


### PR DESCRIPTION
Might be passing the regex assertion if its an outdated token from the past.

fixes #125 