### PR TITLE
Optimize`use_travis_deploy()`

### DIFF
--- a/R/github-key.R
+++ b/R/github-key.R
@@ -53,9 +53,6 @@ add_key <- function(key_data, user, project) {
     key = key_data$key, read_only = key_data$read_only
   )
 
-  cli::cli_alert_info("Adding deploy keys on GitHub and Travis CI for repo
-                      {.code {project}}.")
-
   invisible(resp)
 }
 

--- a/R/setup.R
+++ b/R/setup.R
@@ -97,7 +97,11 @@ use_travis_deploy <- function(path = usethis::proj_get(),
   # check if key(s) exist ------------------------------------------------------
 
   # Github (public key)
-  public_key_exists <- any(gh_keys_names %in% key_name_public)
+  if (!gh_keys[1] == "") {
+    public_key_exists <- any(gh_keys_names %in% key_name_public)
+  } else {
+    public_key_exists <- FALSE
+  }
 
   # Travis (private key)
   private_key_exists <- travis_get_vars(

--- a/R/setup.R
+++ b/R/setup.R
@@ -108,8 +108,9 @@ use_travis_deploy <- function(path = usethis::proj_get(),
     any()
 
   if (private_key_exists && public_key_exists) {
-    return(cli::cli_alert("Deploy keys for Travis CI ({.code {endpoint}})
-                           already present. No action required.", wrap = TRUE))
+    cli::cli_alert("Deploy keys for Travis CI ({.code {endpoint}})
+                           already present. No action required.", wrap = TRUE)
+    return(invisible("Deploy keys already present."))
   } else if (private_key_exists | public_key_exists ||
     !private_key_exists && !public_key_exists) {
     cli::cli_alert("At least one key part is missing (private or public).

--- a/R/setup.R
+++ b/R/setup.R
@@ -39,6 +39,7 @@ use_travis_deploy <- function(path = usethis::proj_get(),
                               quiet = FALSE) {
 
   auth_github()
+  check_endpoint()
   travis_check_api_key()
 
   # generate deploy key pair

--- a/R/setup.R
+++ b/R/setup.R
@@ -17,10 +17,10 @@
 #'   (the GitHub repo to which the public deploy key is added).
 #' @param key_name_private `[string]`\cr
 #'   The name of the private key of the SSH key pair which will be created.
-#'   If not supplied, `"Deploy key for Travis CI (<endpoint>)"` will be used.
+#'   If not supplied, `"TRAVIS_DEPLOY_KEY_<endpoint>"` will be used.
 #' @param key_name_public `[string]`\cr
 #'   The name of the private key of the SSH key pair which will be created.
-#'   Same default as for `key_name_private`.
+#'   If not supplied, `"Deploy key for Travis CI (<endpoint>)"` will be used.
 #' @template endpoint
 #' @template remote
 #' @template quiet
@@ -58,7 +58,7 @@ use_travis_deploy <- function(path = usethis::proj_get(),
 
   if (is.null(key_name_private)) {
     key_name_private <- sprintf(
-      "Deploy key for Travis CI (%s)", endpoint
+      "TRAVIS_DEPLOY_KEY_%s", toupper(sub(".", "", endpoint))
     )
   }
 

--- a/man/use_travis_deploy.Rd
+++ b/man/use_travis_deploy.Rd
@@ -8,6 +8,8 @@ use_travis_deploy(
   path = usethis::proj_get(),
   user = github_user()$login,
   repo = github_info(path = path, remote = remote)$name,
+  key_name_private = NULL,
+  key_name_public = NULL,
   endpoint = get_endpoint(),
   remote = "origin",
   quiet = FALSE
@@ -23,6 +25,14 @@ Name of the Github user account.}
 \item{repo}{\verb{[string]}\cr
 The Travis CI repository to add the private key to, default: \code{repo}
 (the GitHub repo to which the public deploy key is added).}
+
+\item{key_name_private}{\verb{[string]}\cr
+The name of the private key of the SSH key pair which will be created.
+If not supplied, \code{"Deploy key for Travis CI (<endpoint>)"} will be used.}
+
+\item{key_name_public}{\verb{[string]}\cr
+The name of the private key of the SSH key pair which will be created.
+Same default as for \code{key_name_private}.}
 
 \item{endpoint}{\verb{[string]}\cr
 Which Travis endpoint to use. Defaults to ".org". Accepted values are \code{".com"}

--- a/man/use_travis_deploy.Rd
+++ b/man/use_travis_deploy.Rd
@@ -28,11 +28,11 @@ The Travis CI repository to add the private key to, default: \code{repo}
 
 \item{key_name_private}{\verb{[string]}\cr
 The name of the private key of the SSH key pair which will be created.
-If not supplied, \code{"Deploy key for Travis CI (<endpoint>)"} will be used.}
+If not supplied, \code{"TRAVIS_DEPLOY_KEY_<endpoint>"} will be used.}
 
 \item{key_name_public}{\verb{[string]}\cr
 The name of the private key of the SSH key pair which will be created.
-Same default as for \code{key_name_private}.}
+If not supplied, \code{"Deploy key for Travis CI (<endpoint>)"} will be used.}
 
 \item{endpoint}{\verb{[string]}\cr
 Which Travis endpoint to use. Defaults to ".org". Accepted values are \code{".com"}

--- a/tests/testthat/test-use-travis-deploy.R
+++ b/tests/testthat/test-use-travis-deploy.R
@@ -1,0 +1,172 @@
+context("use_travis_deploy")
+
+withr::with_dir(
+  "travis-testthat",
+  {
+    test_that("use_travis_deploy works if the public key is missing", {
+      private_key_exists <- travis_get_vars(
+        # repo = repo,
+        endpoint = ".org"
+      ) %>%
+        purrr::map_lgl(~ .x$name == "Deploy key for Travis CI (.org)") %>%
+        any()
+
+      # delete existing public key from github
+      gh_keys <- gh::gh("/repos/:owner/:repo/keys",
+        owner = "pat-s", repo = "travis-testthat"
+      )
+      gh_keys_names <- gh_keys %>%
+        purrr::map_chr(~ .x$title)
+
+      public_key_exists <- any(gh_keys_names %in%
+        "Deploy key for Travis CI (.org)")
+
+      # delete public key
+      if (public_key_exists) {
+        key_id <- which(gh_keys_names %>%
+          purrr::map_lgl(~ .x == "Deploy key for Travis CI (.org)"))
+        gh::gh("DELETE /repos/:owner/:repo/keys/:key_id",
+          owner = "pat-s",
+          repo = "travis-testthat",
+          key_id = gh_keys[[key_id]]$id
+        )
+      }
+
+      # run function
+      use_travis_deploy()
+
+      # check again if both are present
+      private_key_exists <- travis_get_vars(
+        endpoint = ".org"
+      ) %>%
+        purrr::map_lgl(~ .x$name == "Deploy key for Travis CI (.org)") %>%
+        any()
+
+      # delete existing public key from github
+      gh_keys <- gh::gh("/repos/:owner/:repo/keys",
+        owner = "pat-s", repo = "travis-testthat"
+      )
+      gh_keys_names <- gh_keys %>%
+        purrr::map_chr(~ .x$title)
+
+      public_key_exists <- any(gh_keys_names %in%
+        "Deploy key for Travis CI (.org)")
+
+      expect_true(public_key_exists & private_key_exists)
+    })
+
+    test_that("use_travis_deploy works if the private key is missing", {
+      private_key_exists <- travis_get_vars(
+        # repo = repo,
+        endpoint = ".org"
+      ) %>%
+        purrr::map_lgl(~ .x$name == "Deploy key for Travis CI (.org)") %>%
+        any()
+
+      # delete existing public key from github
+      gh_keys <- gh::gh("/repos/:owner/:repo/keys",
+        owner = "pat-s", repo = "travis-testthat"
+      )
+      gh_keys_names <- gh_keys %>%
+        purrr::map_chr(~ .x$title)
+
+      public_key_exists <- any(gh_keys_names %in%
+        "Deploy key for Travis CI (.org)")
+
+      # delete private key
+      if (private_key_exists) {
+        # delete existing private key from Travis
+        travis_delete_var(travis_get_var_id("Deploy key for Travis CI (.org)",
+          quiet = TRUE
+        ),
+        endpoint = ".org"
+        )
+      }
+
+      # run function
+      use_travis_deploy()
+
+      # check again if both are present
+      private_key_exists <- travis_get_vars(
+        # repo = repo,
+        endpoint = ".org"
+      ) %>%
+        purrr::map_lgl(~ .x$name == "Deploy key for Travis CI (.org)") %>%
+        any()
+
+      # delete existing public key from github
+      gh_keys <- gh::gh("/repos/:owner/:repo/keys",
+        owner = "pat-s", repo = "travis-testthat"
+      )
+      gh_keys_names <- gh_keys %>%
+        purrr::map_chr(~ .x$title)
+
+      public_key_exists <- any(gh_keys_names %in%
+        "Deploy key for Travis CI (.org)")
+
+      expect_true(public_key_exists & private_key_exists)
+    })
+
+    test_that("use_travis_deploy works if the private key is missing", {
+      private_key_exists <- travis_get_vars(
+        # repo = repo,
+        endpoint = ".org"
+      ) %>%
+        purrr::map_lgl(~ .x$name == "Deploy key for Travis CI (.org)") %>%
+        any()
+
+      # delete existing public key from github
+      gh_keys <- gh::gh("/repos/:owner/:repo/keys",
+        owner = "pat-s", repo = "travis-testthat"
+      )
+      gh_keys_names <- gh_keys %>%
+        purrr::map_chr(~ .x$title)
+
+      public_key_exists <- any(gh_keys_names %in%
+        "Deploy key for Travis CI (.org)")
+
+      # delete private key
+      if (private_key_exists) {
+        # delete existing private key from Travis
+        travis_delete_var(travis_get_var_id("Deploy key for Travis CI (.org)",
+          quiet = TRUE
+        ),
+        endpoint = ".org"
+        )
+      }
+      # delete public key
+      if (public_key_exists) {
+        key_id <- which(gh_keys_names %>%
+          purrr::map_lgl(~ .x == "Deploy key for Travis CI (.org)"))
+        gh::gh("DELETE /repos/:owner/:repo/keys/:key_id",
+          owner = "pat-s",
+          repo = "travis-testthat",
+          key_id = gh_keys[[key_id]]$id
+        )
+      }
+
+      # run function
+      use_travis_deploy()
+
+      # check again if both are present
+      private_key_exists <- travis_get_vars(
+        # repo = repo,
+        endpoint = ".org"
+      ) %>%
+        purrr::map_lgl(~ .x$name == "Deploy key for Travis CI (.org)") %>%
+        any()
+
+      # delete existing public key from github
+      gh_keys <- gh::gh("/repos/:owner/:repo/keys",
+        owner = "pat-s", repo = "travis-testthat"
+      )
+      gh_keys_names <- gh_keys %>%
+        purrr::map_chr(~ .x$title)
+
+      public_key_exists <- any(gh_keys_names %in%
+        "Deploy key for Travis CI (.org)")
+
+      expect_true(public_key_exists & private_key_exists)
+    })
+  }
+)

--- a/tests/testthat/test-use-travis-deploy.R
+++ b/tests/testthat/test-use-travis-deploy.R
@@ -107,7 +107,7 @@ withr::with_dir(
       expect_true(public_key_exists & private_key_exists)
     })
 
-    test_that("use_travis_deploy works if the private key is missing", {
+    test_that("use_travis_deploy works if both private and public key are missing", {
       private_key_exists <- travis_get_vars(
         # repo = repo,
         endpoint = ".org"
@@ -167,6 +167,13 @@ withr::with_dir(
         "Deploy key for Travis CI (.org)")
 
       expect_true(public_key_exists & private_key_exists)
+    })
+
+    test_that("use_travis_deploy returns early if both keys are present", {
+
+      # run function
+      foo <- use_travis_deploy()
+      expect_match(foo, "Deploy keys already present.")
     })
   }
 )

--- a/tests/testthat/test-use-travis-deploy.R
+++ b/tests/testthat/test-use-travis-deploy.R
@@ -76,7 +76,7 @@ withr::with_dir(
       # delete private key
       if (private_key_exists) {
         # delete existing private key from Travis
-        travis_delete_var(travis_get_var_id("Deploy key for Travis CI (.org)",
+        travis_delete_var(travis_get_var_id("TRAVIS_DEPLOY_KEY_ORG",
           quiet = TRUE
         ),
         endpoint = ".org"
@@ -128,7 +128,7 @@ withr::with_dir(
       # delete private key
       if (private_key_exists) {
         # delete existing private key from Travis
-        travis_delete_var(travis_get_var_id("Deploy key for Travis CI (.org)",
+        travis_delete_var(travis_get_var_id("TRAVIS_DEPLOY_KEY_ORG",
           quiet = TRUE
         ),
         endpoint = ".org"

--- a/tests/testthat/test-use-travis-deploy.R
+++ b/tests/testthat/test-use-travis-deploy.R
@@ -4,6 +4,10 @@ withr::with_dir(
   "travis-testthat",
   {
     test_that("use_travis_deploy works if the public key is missing", {
+      skip_if(
+        !Sys.getenv("TRAVIS_PULL_REQUEST") == "false",
+        "Skipping test on PR to avoid race conditions."
+      )
       private_key_exists <- travis_get_vars(
         # repo = repo,
         endpoint = ".org"
@@ -56,6 +60,11 @@ withr::with_dir(
     })
 
     test_that("use_travis_deploy works if the private key is missing", {
+      skip_if(
+        !Sys.getenv("TRAVIS_PULL_REQUEST") == "false",
+        "Skipping test on PR to avoid race conditions."
+      )
+
       private_key_exists <- travis_get_vars(
         # repo = repo,
         endpoint = ".org"
@@ -170,6 +179,10 @@ withr::with_dir(
     })
 
     test_that("use_travis_deploy returns early if both keys are present", {
+      skip_if(
+        !Sys.getenv("TRAVIS_PULL_REQUEST") == "false",
+        "Skipping test on PR to avoid race conditions."
+      )
 
       # run function
       foo <- use_travis_deploy()


### PR DESCRIPTION
fixes #120 

* `use_travis_deploy()` now has the capability to check whether one part of the key pair is missing and if, delete the still existing part and create a new key pair
* one can now set the name of the key pair via args `key_name_private` and `key_name_public`
* optimized cli output
* the function structure is now better:
  1. Clear old leftover keys
  1. Check if keys exist, eventually return early
  1. Delete existing keys if at least one is missing
  1. Create new keys

* default for private key: `TRAVIS_DEPLOY_KEY_<endpoint>`
* default for public key: `"Deploy key for Travis CI (<endpoint>)"`

We still return early if both keys exist.
I think this is really important since otherwise users will always have the delete/process on every run of `use_travis_deploy()`. This can become somewhat annoying, also when being used in `use_tic()` for example.

I still need to add tests which check for the special conditions.

# Tests

I've added a GITHUB_TOKEN of mine to use `gh::gh()` within the tests to delete public keys of the test repo `pat-s/testthat`. We check all scenarios:

- both keys missing
- only one key missing
- all keys present.