### PR TITLE
Update the name of a function

### DIFF
--- a/vignettes/travis.Rmd
+++ b/vignettes/travis.Rmd
@@ -79,7 +79,7 @@ With an existing project that exists on Github, one can
 1. Enable the repository on Travis
 
     ```r
-    travis::enable()
+    travis::travis_enable()
     ```
 
 1. Enable deployment for this repository


### PR DESCRIPTION
I noticed that `enable` was renamed to `travis_enable`